### PR TITLE
fix: preserveAspectRatio on snapshots without freeResize

### DIFF
--- a/chart-modules/common/picasso/chart-view.js
+++ b/chart-modules/common/picasso/chart-view.js
@@ -136,15 +136,13 @@ const ChartView = Class.extend({
   },
 
   addSnapshotChartSettings(settings, layout) {
-    const { freeResize, maximizeSnapshot } = this.environment.options;
+    const { freeResize } = this.environment.options;
     if (!freeResize && layout.snapshotData) {
       settings.dockLayout.logicalSize = {
         width: layout.snapshotData.content.size.w,
         height: layout.snapshotData.content.size.h,
+        preserveAspectRatio: true,
       };
-      if (maximizeSnapshot) {
-        settings.dockLayout.logicalSize.preserveAspectRatio = true;
-      }
     }
   },
 


### PR DESCRIPTION
remove use of maximizeSnapshot option as preserveAspectRatio should be kept without it
(also it is not sent to supernova charts in sense-client)

fix #6