### PR TITLE
fix: add snapshotData if missing

### DIFF
--- a/chart-modules/common/picasso/chart-view.js
+++ b/chart-modules/common/picasso/chart-view.js
@@ -194,6 +194,9 @@ const ChartView = Class.extend({
   },
 
   setSnapshotData(snapshotLayout) {
+    if (!snapshotLayout.snapshotData) {
+      snapshotLayout.snapshotData = {};
+    }
     snapshotLayout.snapshotData.content = {
       // eslint-disable-line no-param-reassign
       chartData: {},


### PR DESCRIPTION
add snapshotData if missing when taking a snapshot
for snapshoting in nebula serve