### PR TITLE
fix: do not use setProperties in readonly apps

### DIFF
--- a/chart-modules/common/extra/__tests__/hard-properties-checker.spec.js
+++ b/chart-modules/common/extra/__tests__/hard-properties-checker.spec.js
@@ -1,10 +1,10 @@
 import hardPropertiesChecker from '../hard-properties-checker';
 
 describe('set up state', () => {
-  let propsOrLayout;
+  let layout;
 
   beforeEach(() => {
-    propsOrLayout = {
+    layout = {
       qMeta: {
         privileges: ['update'],
       },
@@ -15,35 +15,42 @@ describe('set up state', () => {
   });
 
   it('should be able to update hard properties', () => {
-    const canModify = hardPropertiesChecker.canModifyHardProperties(propsOrLayout);
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
     expect(canModify).toBe(true);
   });
 
   it('should not allow the user to update hard properties, if no update permissions are allowed', () => {
-    propsOrLayout.qMeta.privileges = [];
-    const canModify = hardPropertiesChecker.canModifyHardProperties(propsOrLayout);
+    layout.qMeta.privileges = [];
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
     expect(canModify).toBe(false);
   });
 
   it('should not allow the user to update hard properties, if there exists soft patches', () => {
-    propsOrLayout.qHasSoftPatches = true;
+    layout.qHasSoftPatches = true;
 
-    const canModify = hardPropertiesChecker.canModifyHardProperties(propsOrLayout);
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
     expect(canModify).toBe(false);
   });
 
   it('should not allow the user to update hard properties, if the object is linked to a master visualization', () => {
-    propsOrLayout.qExtendsId = 'bj763u';
+    layout.qExtendsId = 'bj763u';
 
-    const canModify = hardPropertiesChecker.canModifyHardProperties(propsOrLayout);
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
     expect(canModify).toBe(false);
   });
 
   it('should not allow the user to update hard properties, if the object is linked to a master visualization and have soft patches', () => {
-    propsOrLayout.qExtendsId = 'bj763u';
-    propsOrLayout.qHasSoftPatches = true;
+    layout.qExtendsId = 'bj763u';
+    layout.qHasSoftPatches = true;
 
-    const canModify = hardPropertiesChecker.canModifyHardProperties(propsOrLayout);
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
+    expect(canModify).toBe(false);
+  });
+
+  it('should use permissions mixin if exists as it is correctly do not support uppdate on readonly apps', () => {
+    layout.permissions = { update: false };
+
+    const canModify = hardPropertiesChecker.canModifyHardProperties(layout);
     expect(canModify).toBe(false);
   });
 });

--- a/chart-modules/common/extra/hard-properties-checker.js
+++ b/chart-modules/common/extra/hard-properties-checker.js
@@ -2,9 +2,12 @@ export default {
   canModifyHardProperties,
 };
 
-function canModifyHardProperties(propsOrLayout) {
-  if (propsOrLayout.qHasSoftPatches || propsOrLayout.qExtendsId) {
+function canModifyHardProperties(layout) {
+  if (layout.qHasSoftPatches || layout.qExtendsId) {
     return false;
   }
-  return propsOrLayout.qMeta.privileges.indexOf('update') !== -1;
+  if (layout.permissions) {
+    return layout.permissions.update;
+  }
+  return layout.qMeta.privileges.indexOf('update') !== -1;
 }


### PR DESCRIPTION
simple fix that uses sense-client mixins (and do not work outside sense-client)