### PR TITLE
fix(waterfall): set qSuppressZero to false on conversion

### DIFF
--- a/charts/waterfallchart/src/waterfallchart-import-export.js
+++ b/charts/waterfallchart/src/waterfallchart-import-export.js
@@ -30,6 +30,8 @@ export function importProperties({ dataDefinition, defaultPropertyValues, export
     });
   }
 
+  props.qHyperCubeDef.qSuppressZero = false;
+
   return propTree;
 }
 


### PR DESCRIPTION
Fixes https://jira.qlikdev.com/browse/QB-9016

(Can be reproduced with any chart that can uncheck "Include zero values" before converting to waterfall).