### PR TITLE
feat(boxplot): add property in axis simple mode

### DIFF
--- a/charts/boxplot/src/__tests__/boxplot-properties.spec.js
+++ b/charts/boxplot/src/__tests__/boxplot-properties.spec.js
@@ -737,13 +737,6 @@ describe('boxplot-properties', () => {
       });
     });
 
-    describe('continuousGroup', () => {
-      it('should not show continuousGroup and auto in continuousGroup', () => {
-        expect(boxplotProperties.items.settings.items.dimensionAxis.items.continuousGroup.show).to.be.false;
-        expect(boxplotProperties.items.settings.items.dimensionAxis.items.continuousGroup.items.auto.show).to.be.false;
-      });
-    });
-
     describe('othersGroup', () => {
       describe('label', () => {
         it('should show lable orientation option when has more than 1 dimension', () => {

--- a/charts/boxplot/src/__tests__/boxplot-properties.spec.js
+++ b/charts/boxplot/src/__tests__/boxplot-properties.spec.js
@@ -568,4 +568,270 @@ describe('boxplot-properties', () => {
       });
     });
   });
+
+  describe('measureAxis', () => {
+    describe('startAt', () => {
+      it('should have correct properties', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt).to.have.all.keys([
+          'type',
+          'component',
+          'translation',
+          'readOnly',
+          'options',
+          'defaultValue',
+          'convertFunctions',
+          'classification',
+        ]);
+      });
+
+      it('should have correct type', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.type).to.equal('string');
+      });
+
+      it('should have correct component', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.component).to.equal('dropdown');
+      });
+
+      it('should have correct translation', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.translation).to.equal(
+          'properties.axis.startAt'
+        );
+      });
+
+      describe('readOnly', () => {
+        let readOnly;
+
+        beforeEach(() => {
+          ({ readOnly } = boxplotProperties.items.settings.items.measureAxis.items.startAt);
+        });
+
+        it('should have return true when has autoMinMax is false and not min type', () => {
+          expect(readOnly({ measureAxis: { autoMinMax: false, minMax: 'max' } })).to.be.true;
+        });
+
+        it('should have return true when has autoMinMax is false and is min type, but min is not 0', () => {
+          expect(readOnly({ measureAxis: { autoMinMax: false, minMax: 'min', min: 10 } })).to.be.true;
+        });
+
+        it('should have return false when has autoMinMax is false and is min type, but min is 0', () => {
+          expect(readOnly({ measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } })).to.be.false;
+        });
+
+        it('should have return false when has autoMinMax is true', () => {
+          expect(readOnly({ measureAxis: { autoMinMax: true } })).to.be.false;
+        });
+      });
+
+      it('should have correct defaultValue', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.defaultValue).to.equal('zero');
+      });
+
+      describe('convertFunctions', () => {
+        let get;
+        let set;
+        let args;
+        let setter;
+        sandbox = sinon.createSandbox();
+        const definition = { type: 'string' };
+        const getter = (type) => type;
+
+        beforeEach(() => {
+          args = { properties: { measureAxis: { autoMinMax: true, min: '10' } } };
+          ({ get, set } = boxplotProperties.items.settings.items.measureAxis.items.startAt.convertFunctions);
+          setter = sandbox.stub();
+        });
+
+        afterEach(() => {
+          sandbox.restore();
+        });
+
+        describe('get', () => {
+          it('should convert value to lowest when is autoMinMax', () => {
+            expect(get(getter, definition, args)).to.equal('lowest');
+          });
+
+          it('should convert value to zero when is not autoMinMax, type is min and min is 0', () => {
+            args = {
+              properties: { measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } },
+            };
+            expect(get(getter, definition, args)).to.equal('zero');
+          });
+
+          it('should return value from getter when is not autoMinMax and type is max', () => {
+            args = {
+              properties: {
+                measureAxis: { autoMinMax: false, minMax: 'max', min: 0 },
+              },
+            };
+            expect(get(getter, definition, args)).to.equal('string');
+          });
+        });
+
+        describe('set', () => {
+          it('should call setter three times with correct values when select start at as zero', () => {
+            set('zero', setter, definition, args, '');
+            expect(setter).to.have.been.calledWith('', 'measureAxis.autoMinMax', false);
+            expect(setter).to.have.been.calledWith('', 'measureAxis.minMax', 'min');
+            expect(setter).to.have.been.calledWith('', 'measureAxis.min', 0);
+          });
+
+          it('should call setter one time with correct values when select start at as lowest', () => {
+            set('lowest', setter, definition, args, '');
+            expect(setter).to.have.been.calledWith('', 'measureAxis.autoMinMax', true);
+          });
+        });
+      });
+
+      it('should have correct classification', () => {
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.classification).to.deep.equal({
+          section: 'axis',
+          tags: ['simple'],
+          exclusive: true,
+        });
+      });
+    });
+  });
+
+  describe('dimensionAxis', () => {
+    describe('dimensionAxisTitle', () => {
+      it('shoould return ture when has more than 1 dimension', () => {
+        const properties = {};
+        const args = {
+          layout: {
+            boxplotDef: {
+              qHyperCube: {
+                qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
+              },
+            },
+          },
+        };
+
+        expect(
+          boxplotProperties.items.settings.items.dimensionAxis.items.dimensionAxisTitle.show(
+            properties,
+            undefined,
+            args
+          )
+        ).to.be.true;
+      });
+
+      it('shoould return false when has 1 dimension', () => {
+        const properties = {};
+        const args = {
+          layout: {
+            boxplotDef: {
+              qHyperCube: {
+                qDimensionInfo: [{ cId: '1' }],
+              },
+            },
+          },
+        };
+
+        expect(
+          boxplotProperties.items.settings.items.dimensionAxis.items.dimensionAxisTitle.show(
+            properties,
+            undefined,
+            args
+          )
+        ).to.be.false;
+      });
+    });
+
+    describe('continuousGroup', () => {
+      it('should not show continuousGroup and auto in continuousGroup', () => {
+        expect(boxplotProperties.items.settings.items.dimensionAxis.items.continuousGroup.show).to.be.false;
+        expect(boxplotProperties.items.settings.items.dimensionAxis.items.continuousGroup.items.auto.show).to.be.false;
+      });
+    });
+
+    describe('othersGroup', () => {
+      describe('label', () => {
+        it('should show lable orientation option when has more than 1 dimension', () => {
+          const properties = {};
+          const args = {
+            layout: {
+              boxplotDef: {
+                qHyperCube: {
+                  qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
+                },
+              },
+            },
+          };
+
+          expect(
+            boxplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.label.show(
+              properties,
+              undefined,
+              args
+            )
+          ).to.be.true;
+        });
+
+        it('should not show lable orientation option when has 1 dimension', () => {
+          const properties = {};
+          const args = {
+            layout: {
+              boxplotDef: {
+                qHyperCube: {
+                  qDimensionInfo: [{ cId: '1' }],
+                },
+              },
+            },
+          };
+
+          expect(
+            boxplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.label.show(
+              properties,
+              undefined,
+              args
+            )
+          ).to.be.false;
+        });
+      });
+
+      describe('dock', () => {
+        it('should show lable orientation option when has more than 1 dimension', () => {
+          const properties = {};
+          const args = {
+            layout: {
+              boxplotDef: {
+                qHyperCube: {
+                  qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
+                },
+              },
+            },
+          };
+
+          expect(
+            boxplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.dock.show(
+              properties,
+              undefined,
+              args
+            )
+          ).to.be.true;
+        });
+
+        it('should not show lable orientation option when has 1 dimension', () => {
+          const properties = {};
+          const args = {
+            layout: {
+              boxplotDef: {
+                qHyperCube: {
+                  qDimensionInfo: [{ cId: '1' }],
+                },
+              },
+            },
+          };
+
+          expect(
+            boxplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.dock.show(
+              properties,
+              undefined,
+              args
+            )
+          ).to.be.false;
+        });
+      });
+    });
+  });
 });

--- a/charts/boxplot/src/__tests__/boxplot-properties.spec.js
+++ b/charts/boxplot/src/__tests__/boxplot-properties.spec.js
@@ -624,7 +624,7 @@ describe('boxplot-properties', () => {
       });
 
       it('should have correct defaultValue', () => {
-        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.defaultValue).to.equal('zero');
+        expect(boxplotProperties.items.settings.items.measureAxis.items.startAt.defaultValue).to.equal('lowest');
       });
 
       describe('convertFunctions', () => {

--- a/charts/boxplot/src/__tests__/boxplot-properties.spec.js
+++ b/charts/boxplot/src/__tests__/boxplot-properties.spec.js
@@ -1,5 +1,6 @@
 import chai from 'chai';
 import sinon from 'sinon';
+import * as chartModules from 'qlik-chart-modules';
 import boxplotPropertiesFn from '../boxplot-properties';
 import boxplotSorter from '../sorting/boxplot-sorter';
 import settingsRetriever from '../sorting/boxplot-sorting-settings-retriever';
@@ -630,15 +631,14 @@ describe('boxplot-properties', () => {
         let get;
         let set;
         let args;
-        let setter;
         sandbox = sinon.createSandbox();
         const definition = { type: 'string' };
         const getter = (type) => type;
 
         beforeEach(() => {
+          sandbox.stub(chartModules, 'setValue');
           args = { properties: { measureAxis: { autoMinMax: true, min: '10' } } };
           ({ get, set } = boxplotProperties.items.settings.items.measureAxis.items.startAt.convertFunctions);
-          setter = sandbox.stub();
         });
 
         afterEach(() => {
@@ -668,16 +668,16 @@ describe('boxplot-properties', () => {
         });
 
         describe('set', () => {
-          it('should call setter three times with correct values when select start at as zero', () => {
-            set('zero', setter, definition, args, '');
-            expect(setter).to.have.been.calledWith('', 'measureAxis.autoMinMax', false);
-            expect(setter).to.have.been.calledWith('', 'measureAxis.minMax', 'min');
-            expect(setter).to.have.been.calledWith('', 'measureAxis.min', 0);
+          it('should call setValue three times with correct values when select start at as zero', () => {
+            set('zero', undefined, definition, args, '');
+            expect(chartModules.setValue).to.have.been.calledWith('', 'measureAxis.autoMinMax', false);
+            expect(chartModules.setValue).to.have.been.calledWith('', 'measureAxis.minMax', 'min');
+            expect(chartModules.setValue).to.have.been.calledWith('', 'measureAxis.min', 0);
           });
 
-          it('should call setter one time with correct values when select start at as lowest', () => {
-            set('lowest', setter, definition, args, '');
-            expect(setter).to.have.been.calledWith('', 'measureAxis.autoMinMax', true);
+          it('should call setValue one time with correct values when select start at as lowest', () => {
+            set('lowest', undefined, definition, args, '');
+            expect(chartModules.setValue).to.have.been.calledWith('', 'measureAxis.autoMinMax', true);
           });
         });
       });

--- a/charts/boxplot/src/boxplot-properties.js
+++ b/charts/boxplot/src/boxplot-properties.js
@@ -333,7 +333,7 @@ export default function propertyDefinition(env) {
             translation: 'properties.axis.startAt.lowest',
           },
         ],
-        defaultValue: 'zero',
+        defaultValue: 'lowest',
         convertFunctions: {
           get(getter, definition, args) {
             const { autoMinMax, minMax, min } = args.properties?.measureAxis || {};

--- a/charts/boxplot/src/boxplot-properties.js
+++ b/charts/boxplot/src/boxplot-properties.js
@@ -365,24 +365,22 @@ export default function propertyDefinition(env) {
   };
 
   const dimensionAxis = {
-    uses: 'axis.dimensionAxis',
+    uses: 'axis.picasso.dimensionAxis',
     show(properties, handler, args) {
       const hasSecondDimension = getValue(args.layout, 'boxplotDef.qHyperCube.qDimensionInfo.length') > 1;
       return hasSecondDimension;
     },
     items: {
       dimensionAxisTitle: {
+        component: 'header',
+        type: 'string',
         show(properties, handler, args) {
           return getValue(args.layout, 'boxplotDef.qHyperCube.qDimensionInfo.length') > 1;
         },
-      },
-      continuousGroup: {
-        type: 'items',
-        show: false,
-        items: {
-          auto: {
-            show: false,
-          },
+        classification: {
+          section: 'axis',
+          tags: ['simple'],
+          exclusive: true,
         },
       },
       othersGroup: {

--- a/charts/boxplot/src/boxplot-properties.js
+++ b/charts/boxplot/src/boxplot-properties.js
@@ -347,11 +347,11 @@ export default function propertyDefinition(env) {
           },
           set(value, setter, definition, args, data) {
             if (value === 'zero') {
-              setter(data, 'measureAxis.autoMinMax', false);
-              setter(data, 'measureAxis.minMax', 'min');
-              setter(data, 'measureAxis.min', 0);
+              setValue(data, 'measureAxis.autoMinMax', false);
+              setValue(data, 'measureAxis.minMax', 'min');
+              setValue(data, 'measureAxis.min', 0);
             } else {
-              setter(data, 'measureAxis.autoMinMax', true);
+              setValue(data, 'measureAxis.autoMinMax', true);
             }
           },
         },


### PR DESCRIPTION
Add start at property and some adjustment to axis presentation in simple edit mode.

~~I have to change dimension use from `uses: 'axis.picasso.dimensionAxis',` to `uses: 'axis.dimensionAxis',` in order to show title is simple edit mode. I am not sure why, but I tested the changes, the properties look correct.~~ I know why now

![Screenshot 2022-05-13 at 10 31 20](https://user-images.githubusercontent.com/25456307/168244626-1370c03e-7a22-4f29-8ed1-d1746cdf39fd.png)


https://user-images.githubusercontent.com/25456307/168244658-378bb4d6-beb1-47a9-a369-e67184c46105.mov


