### PR TITLE
refactor: use data

### DIFF
--- a/charts/boxplot/src/__tests__/boxplot-properties.spec.js
+++ b/charts/boxplot/src/__tests__/boxplot-properties.spec.js
@@ -102,15 +102,15 @@ describe('boxplot-properties', () => {
         it('should call boxplot-sorting-service.applySorting with correct arguments', () => {
           const properties = {};
 
-          const args = {
+          const handler = {
             layout: {},
           };
 
-          autoSort.change({}, {}, properties, args);
+          autoSort.change({}, handler, properties, {});
 
           expect(boxplotSorter.applySorting.calledOnce, 'boxplotSorter.applySorting call count').to.be.true;
           expect(
-            boxplotSorter.applySorting.calledWithExactly(properties, args.layout, translator),
+            boxplotSorter.applySorting.calledWithExactly(properties, handler.layout, translator),
             'boxplotSorter.applySorting arguments'
           ).to.be.true;
         });
@@ -576,14 +576,14 @@ describe('boxplot-properties', () => {
           describe('elements', () => {
             it('should reject promise if qUndoExclude or qUndoExclude.hashCode is missing', () => {
               const args = {
-                properties: {},
+                handler: { properties: {} },
               };
 
               simpleSorting.elements(args);
 
               expect(Promise.reject.calledOnce, 'no qUndoExclude').to.be.true;
 
-              args.properties.qUndoExclude = {};
+              args.handler.properties.qUndoExclude = {};
 
               Promise.reject.reset();
 
@@ -596,25 +596,27 @@ describe('boxplot-properties', () => {
               const measures = [];
 
               const args = {
-                properties: {
-                  qUndoExclude: {
-                    hashCode: 123,
-                    box: {
-                      qHyperCubeDef: {
-                        qMeasures: measures,
+                handler: {
+                  properties: {
+                    qUndoExclude: {
+                      hashCode: 123,
+                      box: {
+                        qHyperCubeDef: {
+                          qMeasures: measures,
+                        },
                       },
                     },
                   },
-                },
-                layout: {
-                  boxplotDef: {
-                    qHyperCube: {
-                      qDimensionInfo: [
-                        {},
-                        {
-                          qCardinal: 42,
-                        },
-                      ],
+                  layout: {
+                    boxplotDef: {
+                      qHyperCube: {
+                        qDimensionInfo: [
+                          {},
+                          {
+                            qCardinal: 42,
+                          },
+                        ],
+                      },
                     },
                   },
                 },
@@ -624,7 +626,7 @@ describe('boxplot-properties', () => {
 
               expect(elementsRetriever.getElements.calledOnce, 'elementsRetriever.getElements call count').to.be.true;
               expect(
-                elementsRetriever.getElements.calledWithExactly(args.properties, returnedSettings, translator),
+                elementsRetriever.getElements.calledWithExactly(args.handler.properties, returnedSettings, translator),
                 'calledWithExactly'
               ).to.be.true;
             });
@@ -633,25 +635,27 @@ describe('boxplot-properties', () => {
               const measures = [];
 
               const args = {
-                properties: {
-                  qUndoExclude: {
-                    hashCode: 123,
-                    box: {
-                      qHyperCubeDef: {
-                        qMeasures: measures,
+                handler: {
+                  properties: {
+                    qUndoExclude: {
+                      hashCode: 123,
+                      box: {
+                        qHyperCubeDef: {
+                          qMeasures: measures,
+                        },
                       },
                     },
                   },
-                },
-                layout: {
-                  boxplotDef: {
-                    qHyperCube: {
-                      qDimensionInfo: [
-                        {},
-                        {
-                          qCardinal: 42,
-                        },
-                      ],
+                  layout: {
+                    boxplotDef: {
+                      qHyperCube: {
+                        qDimensionInfo: [
+                          {},
+                          {
+                            qCardinal: 42,
+                          },
+                        ],
+                      },
                     },
                   },
                 },
@@ -792,14 +796,15 @@ describe('boxplot-properties', () => {
       describe('convertFunctions', () => {
         let get;
         let set;
-        let args;
+        let data;
         sandbox = sinon.createSandbox();
         const definition = { type: 'string' };
         const getter = (type) => type;
+        const args = {};
 
         beforeEach(() => {
           sandbox.stub(chartModules, 'setValue');
-          args = { properties: { measureAxis: { autoMinMax: true, min: '10' } } };
+          data = { measureAxis: { autoMinMax: true, min: '10' } };
           ({ get, set } = boxplotProperties.items.settings.items.measureAxis.items.startAt.convertFunctions);
         });
 
@@ -809,23 +814,17 @@ describe('boxplot-properties', () => {
 
         describe('get', () => {
           it('should convert value to lowest when is autoMinMax', () => {
-            expect(get(getter, definition, args)).to.equal('lowest');
+            expect(get(getter, definition, args, data)).to.equal('lowest');
           });
 
           it('should convert value to zero when is not autoMinMax, type is min and min is 0', () => {
-            args = {
-              properties: { measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } },
-            };
-            expect(get(getter, definition, args)).to.equal('zero');
+            data = { measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } };
+            expect(get(getter, definition, args, data)).to.equal('zero');
           });
 
           it('should return value from getter when is not autoMinMax and type is max', () => {
-            args = {
-              properties: {
-                measureAxis: { autoMinMax: false, minMax: 'max', min: 0 },
-              },
-            };
-            expect(get(getter, definition, args)).to.equal('string');
+            data = { measureAxis: { autoMinMax: false, minMax: 'max', min: 0 } };
+            expect(get(getter, definition, args, data)).to.equal('string');
           });
         });
 

--- a/charts/boxplot/src/boxplot-properties.js
+++ b/charts/boxplot/src/boxplot-properties.js
@@ -91,6 +91,7 @@ export default function propertyDefinition(env) {
           autoColor: {
             ref: 'boxplotDef.color.auto',
             type: 'boolean',
+            forceLabel: true,
             label: (data) => {
               if (getValue(data, 'boxplotDef.color.auto'))
                 return translator.get('Simple.Color.Auto', translator.get('properties.colorMode.primary'));
@@ -341,8 +342,8 @@ export default function propertyDefinition(env) {
         ],
         defaultValue: 'lowest',
         convertFunctions: {
-          get(getter, definition, args) {
-            const { autoMinMax, minMax, min } = args.properties?.measureAxis || {};
+          get(getter, definition, args, data) {
+            const { autoMinMax, minMax, min } = data?.measureAxis || {};
             if (autoMinMax === true) {
               return 'lowest';
             }
@@ -434,10 +435,10 @@ export default function propertyDefinition(env) {
       labels: {
         items: {
           header: {
-            show(props, handler, args) {
+            show(props) {
               return (
-                args.properties.boxplotDef?.qHyperCubeDef?.qDimensions?.length &&
-                args.properties.boxplotDef?.qHyperCubeDef?.qMeasures?.length
+                props.boxplotDef?.qHyperCubeDef?.qDimensions?.length &&
+                props.boxplotDef?.qHyperCubeDef?.qMeasures?.length
               );
             },
           },
@@ -447,18 +448,18 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.Dimension.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
+            show(props) {
               return (
-                args.properties.boxplotDef?.qHyperCubeDef?.qDimensions?.length > 1 &&
-                args.properties.boxplotDef?.qHyperCubeDef?.qMeasures?.length
+                props.boxplotDef?.qHyperCubeDef?.qDimensions?.length > 1 &&
+                props.boxplotDef?.qHyperCubeDef?.qMeasures?.length
               );
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.dimensionAxis.show === 'labels' || args.properties.dimensionAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.dimensionAxis.show === 'labels' || data.dimensionAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.dimensionAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.dimensionAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -468,18 +469,18 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.Measure.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
+            show(props) {
               return (
-                args.properties.boxplotDef?.qHyperCubeDef?.qDimensions?.length &&
-                args.properties.boxplotDef?.qHyperCubeDef?.qMeasures?.length
+                props.boxplotDef?.qHyperCubeDef?.qDimensions?.length &&
+                props.boxplotDef?.qHyperCubeDef?.qMeasures?.length
               );
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.measureAxis.show === 'labels' || args.properties.measureAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.measureAxis.show === 'labels' || data.measureAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.measureAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.measureAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -565,8 +566,8 @@ export default function propertyDefinition(env) {
           },
         ],
         show: hasMultipleDimensions,
-        change(data, handler, properties, args) {
-          boxplotSorter.applySorting(properties, args.layout, translator);
+        change(data, handler) {
+          boxplotSorter.applySorting(data, handler.layout, translator);
         },
         classification: {
           section: 'sorting',
@@ -579,12 +580,12 @@ export default function propertyDefinition(env) {
         elementRef: SORTING_REFS.ELEMENT_ID,
         sortCriteriasRef: SORTING_REFS.SORT_CRITERIA,
         elements(args) {
-          if (!args.properties.qUndoExclude || !args.properties.qUndoExclude.hashCode) {
+          if (!args.handler.properties.qUndoExclude || !args.handler.properties.qUndoExclude.hashCode) {
             return Promise.reject();
           }
 
-          const settings = settingsRetriever.getSettings(args.layout);
-          const elements = elementsRetriever.getElements(args.properties, settings, translator);
+          const settings = settingsRetriever.getSettings(args.handler.layout);
+          const elements = elementsRetriever.getElements(args.handler.properties, settings, translator);
 
           return Promise.resolve(elements);
         },


### PR DESCRIPTION
For auto chart to show inner object properties in simple mode, we have to pass in inner object properties to properties panel. 

- Replace the places where using args.properties(auto chart properties) to props(data)
- Replace using properties and layout from handler in sorting
- Add `forceLabel: true` to show correct color label.

https://user-images.githubusercontent.com/25456307/172388628-f3fedede-80f2-402f-9629-b22f5384d424.mov


![Screenshot 2022-06-07 at 15 13 11](https://user-images.githubusercontent.com/25456307/172388867-c5767afa-190b-4bd5-8289-d33232a7f86b.png)
![Screenshot 2022-06-07 at 15 13 17](https://user-images.githubusercontent.com/25456307/172388876-4decd44a-3ffe-4100-8fc5-b0c0bda49d24.png)



