### PR TITLE
refactor(distplot): use data instead of args properties

### DIFF
--- a/charts/distributionplot/src/__tests__/distributionplot-properties.spec.js
+++ b/charts/distributionplot/src/__tests__/distributionplot-properties.spec.js
@@ -122,14 +122,15 @@ describe('distributionplot-properties', () => {
       describe('convertFunctions', () => {
         let get;
         let set;
-        let args;
+        let data;
         sandbox = sinon.createSandbox();
         const definition = { type: 'string' };
         const getter = (type) => type;
+        const args = {};
 
         beforeEach(() => {
           sandbox.stub(chartModules, 'setValue');
-          args = { properties: { measureAxis: { autoMinMax: true, min: '10' } } };
+          data = { measureAxis: { autoMinMax: true, min: '10' } };
           ({ get, set } = distributionplotProperties.items.settings.items.measureAxis.items.startAt.convertFunctions);
         });
 
@@ -139,23 +140,17 @@ describe('distributionplot-properties', () => {
 
         describe('get', () => {
           it('should convert value to lowest when is autoMinMax', () => {
-            expect(get(getter, definition, args)).to.equal('lowest');
+            expect(get(getter, definition, args, data)).to.equal('lowest');
           });
 
           it('should convert value to zero when is not autoMinMax, type is min and min is 0', () => {
-            args = {
-              properties: { measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } },
-            };
-            expect(get(getter, definition, args)).to.equal('zero');
+            data = { measureAxis: { autoMinMax: false, minMax: 'min', min: 0 } };
+            expect(get(getter, definition, args, data)).to.equal('zero');
           });
 
           it('should return value from getter when is not autoMinMax and type is max', () => {
-            args = {
-              properties: {
-                measureAxis: { autoMinMax: false, minMax: 'max', min: 0 },
-              },
-            };
-            expect(get(getter, definition, args)).to.equal('string');
+            data = { measureAxis: { autoMinMax: false, minMax: 'max', min: 0 } };
+            expect(get(getter, definition, args, data)).to.equal('string');
           });
         });
 
@@ -187,7 +182,7 @@ describe('distributionplot-properties', () => {
     describe('dimensionAxisTitle', () => {
       it('shoould return ture when has more than 1 dimension', () => {
         const properties = {};
-        const args = {
+        const handler = {
           layout: {
             qHyperCube: {
               qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
@@ -198,15 +193,14 @@ describe('distributionplot-properties', () => {
         expect(
           distributionplotProperties.items.settings.items.dimensionAxis.items.dimensionAxisTitle.show(
             properties,
-            undefined,
-            args
+            handler
           )
         ).to.be.true;
       });
 
       it('shoould return false when has 1 dimension', () => {
         const properties = {};
-        const args = {
+        const handler = {
           layout: {
             qHyperCube: {
               qDimensionInfo: [{ cId: '1' }],
@@ -217,8 +211,7 @@ describe('distributionplot-properties', () => {
         expect(
           distributionplotProperties.items.settings.items.dimensionAxis.items.dimensionAxisTitle.show(
             properties,
-            undefined,
-            args
+            handler
           )
         ).to.be.false;
       });
@@ -228,7 +221,7 @@ describe('distributionplot-properties', () => {
       describe('label', () => {
         it('should show lable orientation option when has more than 1 dimension', () => {
           const properties = {};
-          const args = {
+          const handler = {
             layout: {
               qHyperCube: {
                 qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
@@ -239,15 +232,14 @@ describe('distributionplot-properties', () => {
           expect(
             distributionplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.label.show(
               properties,
-              undefined,
-              args
+              handler
             )
           ).to.be.true;
         });
 
         it('should not show lable orientation option when has 1 dimension', () => {
           const properties = {};
-          const args = {
+          const handler = {
             layout: {
               boxplotDef: {
                 qHyperCube: {
@@ -260,8 +252,7 @@ describe('distributionplot-properties', () => {
           expect(
             distributionplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.label.show(
               properties,
-              undefined,
-              args
+              handler
             )
           ).to.be.false;
         });
@@ -270,7 +261,7 @@ describe('distributionplot-properties', () => {
       describe('dock', () => {
         it('should show lable orientation option when has more than 1 dimension', () => {
           const properties = {};
-          const args = {
+          const handler = {
             layout: {
               qHyperCube: {
                 qDimensionInfo: [{ cId: '1' }, { cId: '2' }],
@@ -281,15 +272,14 @@ describe('distributionplot-properties', () => {
           expect(
             distributionplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.dock.show(
               properties,
-              undefined,
-              args
+              handler
             )
           ).to.be.true;
         });
 
         it('should not show lable orientation option when has 1 dimension', () => {
           const properties = {};
-          const args = {
+          const handler = {
             layout: {
               qHyperCube: {
                 qDimensionInfo: [{ cId: '1' }],
@@ -300,8 +290,7 @@ describe('distributionplot-properties', () => {
           expect(
             distributionplotProperties.items.settings.items.dimensionAxis.items.othersGroup.items.dock.show(
               properties,
-              undefined,
-              args
+              handler
             )
           ).to.be.false;
         });

--- a/charts/distributionplot/src/distributionplot-properties.js
+++ b/charts/distributionplot/src/distributionplot-properties.js
@@ -337,8 +337,8 @@ export default function propertyDefinition(env) {
         ],
         defaultValue: 'lowest',
         convertFunctions: {
-          get(getter, definition, args) {
-            const { autoMinMax, minMax, min } = args.properties?.measureAxis || {};
+          get(getter, definition, args, data) {
+            const { autoMinMax, minMax, min } = data?.measureAxis || {};
             if (autoMinMax === true) {
               return 'lowest';
             }
@@ -368,16 +368,16 @@ export default function propertyDefinition(env) {
 
   const dimensionAxis = {
     uses: 'axis.picasso.dimensionAxis',
-    show(properties, handler, args) {
-      const hasSecondDimension = getValue(args.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
+    show(properties, handler) {
+      const hasSecondDimension = getValue(handler.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
       return hasSecondDimension;
     },
     items: {
       dimensionAxisTitle: {
         component: 'header',
         type: 'string',
-        show(properties, handler, args) {
-          return getValue(args.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
+        show(properties, handler) {
+          return getValue(handler.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
         },
         classification: {
           section: 'axis',
@@ -388,10 +388,10 @@ export default function propertyDefinition(env) {
       othersGroup: {
         items: {
           label: {
-            show(properties, handler, args) {
+            show(properties, handler) {
               return (
-                getValue(args.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1 &&
-                getValue(args.layout, 'orientation') !== 'horizontal'
+                getValue(handler.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1 &&
+                getValue(handler.layout, 'orientation') !== 'horizontal'
               );
             },
             options: flags.isEnabled('SENSECLIENT_LAYERED_LABELS')
@@ -416,8 +416,8 @@ export default function propertyDefinition(env) {
               : undefined,
           },
           dock: {
-            show(properties, handler, args) {
-              return getValue(args.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
+            show(properties, handler) {
+              return getValue(handler.layout, `${CONSTANTS.HYPERCUBE_PATH}.qDimensionInfo.length`) > 1;
             },
           },
         },
@@ -813,10 +813,8 @@ export default function propertyDefinition(env) {
       labels: {
         items: {
           header: {
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions?.length && args.properties.qHyperCubeDef.qMeasures?.length
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions?.length && props.qHyperCubeDef.qMeasures?.length;
             },
           },
           dimensionTitle: {
@@ -825,17 +823,15 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.Dimension.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions?.length > 1 && args.properties.qHyperCubeDef.qMeasures?.length
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions?.length > 1 && props.qHyperCubeDef.qMeasures?.length;
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.dimensionAxis.show === 'labels' || args.properties.dimensionAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.dimensionAxis.show === 'labels' || data.dimensionAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.dimensionAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.dimensionAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -845,17 +841,15 @@ export default function propertyDefinition(env) {
             type: 'string',
             translation: 'Simple.Label.Measure.Hide',
             defaultValue: 'all',
-            show(props, handler, args) {
-              return (
-                args.properties.qHyperCubeDef.qDimensions?.length && args.properties.qHyperCubeDef.qMeasures?.length
-              );
+            show(props) {
+              return props.qHyperCubeDef.qDimensions?.length && props.qHyperCubeDef.qMeasures?.length;
             },
             convertFunctions: {
-              get(getter, def, args) {
-                return args.properties.measureAxis.show === 'labels' || args.properties.measureAxis.show === 'none';
+              get(getter, def, args, data) {
+                return data.measureAxis.show === 'labels' || data.measureAxis.show === 'none';
               },
-              set(value, setter, def, args) {
-                args.properties.measureAxis.show = value ? 'labels' : 'all';
+              set(value, setter, def, args, data) {
+                data.measureAxis.show = value ? 'labels' : 'all';
               },
             },
           },
@@ -956,8 +950,8 @@ export default function propertyDefinition(env) {
         ],
         show: distplotUtils.hasMultipleDimensions,
         change(data, handler, properties, args) {
-          if (properties && distplotUtils.hasMultipleDimensions(properties) && args.layout) {
-            return distplotSorter.applySorting(properties, args.layout, args.model.app, null, translator);
+          if (data && distplotUtils.hasMultipleDimensions(data) && handler.layout) {
+            return distplotSorter.applySorting(data, handler.layout, args.model.app, null, translator);
           }
           return undefined;
         },
@@ -976,8 +970,8 @@ export default function propertyDefinition(env) {
         },
         elements(args) {
           return HyperCubeDefGenerator.getAllHyperCubeExpressions(
-            args.properties.qHyperCubeDef,
-            args.layout.qHyperCube,
+            args.handler.properties.qHyperCubeDef,
+            args.handler.layout.qHyperCube,
             args.model.app
           ).then((expressions) => {
             const settings = settingsRetriever.getSettings(args.layout);


### PR DESCRIPTION
For auto chart to show inner object properties in simple mode, we have to pass in inner object properties to properties panel.

https://user-images.githubusercontent.com/25456307/172406932-274a4a1d-3290-4c89-8a16-80891a0745b3.mov


