### PR TITLE
fix: reset sorting for boxplot and distribution plot

### DIFF
--- a/charts/boxplot/src/boxplot-properties.js
+++ b/charts/boxplot/src/boxplot-properties.js
@@ -600,15 +600,6 @@ export default function propertyDefinition(env) {
           tags: ['simple'],
           exclusive: true,
         },
-        reset(data) {
-          const sortCriteria = getValue(data, SORTING_REFS.SORT_CRITERIA, {});
-          Object.keys(sortCriteria).forEach((key) => {
-            sortCriteria[key] = 1;
-          });
-          if (sortCriteria.sortByExpression !== undefined) {
-            sortCriteria.sortByExpression = 0;
-          }
-        },
       },
       sortingItems: {
         component: 'items',

--- a/charts/distributionplot/src/distributionplot-properties.js
+++ b/charts/distributionplot/src/distributionplot-properties.js
@@ -1010,15 +1010,6 @@ export default function propertyDefinition(env) {
           tags: ['simple'],
           exclusive: true,
         },
-        reset(data) {
-          const sortCriteria = getValue(data, CONSTANTS.SORT_CRITERIA, {});
-          Object.keys(sortCriteria).forEach((key) => {
-            sortCriteria[key] = 1;
-          });
-          if (sortCriteria.sortByExpression !== undefined) {
-            sortCriteria.sortByExpression = 0;
-          }
-        },
       },
       sortingItems: {
         type: 'items',


### PR DESCRIPTION
### Summary
Resetting simply set `sorting` to `{autoSort:true}`. This is basically the fresh state when a box plot or a distribution plot is created.
(Idea credited to  @T-Wizard)

### Verification
- Box plot:

https://user-images.githubusercontent.com/70384379/172834840-916e6455-570b-4b40-8b49-d520dbf63fa9.mov

- Distribution plot:

https://user-images.githubusercontent.com/70384379/172834647-59ac1b1f-654a-4228-bf0a-aeea50708747.mov

- Distribution plot when the outer dimension has more than 10 items

https://user-images.githubusercontent.com/70384379/172834302-88bf587a-9a06-4151-bac8-e8b6cbeaf34f.mov


