### PR TITLE
feat(dist-plot): library color in simple mode

### DIFF
--- a/charts/distributionplot/src/__tests__/distributionplot-properties-logic.spec.js
+++ b/charts/distributionplot/src/__tests__/distributionplot-properties-logic.spec.js
@@ -163,7 +163,7 @@ describe('distributionplot-properties-logic', () => {
 
   it('should expose the correct api', () => {
     expect(distplotPropsLogic).to.be.an('object');
-    expect(Object.keys(distplotPropsLogic).length).to.equal(13);
+    expect(Object.keys(distplotPropsLogic).length).to.equal(14);
   });
 
   // Test exposed methods
@@ -292,6 +292,42 @@ describe('distributionplot-properties-logic', () => {
 
       expect(data.qUndoExclude.qHyperCubeDef.qCalcCond).to.equals('qCalcCond');
       expect(data.qUndoExclude.qHyperCubeDef.qCalcCondition).to.equals('qCalcCondition');
+    });
+  });
+
+  describe('hasDimValueColors', () => {
+    it('should return correct hasValueColors', () => {
+      const handler = {
+        layout: {
+          qHyperCube: {
+            qDimensionInfo: [
+              {
+                qLibraryId: 'test',
+                coloring: { hasValueColors: false },
+              },
+            ],
+          },
+        },
+      };
+
+      expect(distplotPropsLogic.hasDimValueColors(handler, 'test')).to.be.false;
+    });
+
+    it('should return true when has no hasValueColors value', () => {
+      const handler = {
+        layout: {
+          qHyperCube: {
+            qDimensionInfo: [
+              {
+                qLibraryId: 'test',
+                coloring: {},
+              },
+            ],
+          },
+        },
+      };
+
+      expect(distplotPropsLogic.hasDimValueColors(handler, 'test')).to.be.true;
     });
   });
 });

--- a/charts/distributionplot/src/distributionplot-properties-logic.js
+++ b/charts/distributionplot/src/distributionplot-properties-logic.js
@@ -86,6 +86,12 @@ function onChangeCalcCond(data) {
   }
 }
 
+function hasDimValueColors(handler, libraryId) {
+  const dims = getValue(handler, 'layout.qHyperCube.qDimensionInfo', []);
+  const activeDim = dims.filter((d) => d?.qLibraryId === libraryId);
+  return activeDim[0]?.coloring?.hasValueColors ?? true;
+}
+
 export default {
   measuresHasBaseColors,
   dimensionsHasBaseColors,
@@ -101,4 +107,5 @@ export default {
   isMeasureLibraryItem,
   showLegend,
   showColorByLabel,
+  hasDimValueColors,
 };

--- a/charts/distributionplot/src/distributionplot-properties.js
+++ b/charts/distributionplot/src/distributionplot-properties.js
@@ -484,12 +484,12 @@ export default function propertyDefinition(env) {
     items: {
       disclaimer: {
         show(data, handler) {
-          return showDisclaimer(data, handler);
+          return flags.isEnabled('SIMPLE_PROPERTIES_LIBRARY_COLOR') ? false : showDisclaimer(data, handler);
         },
       },
       simpleItems: {
         show(data, handler) {
-          return !showDisclaimer(data, handler);
+          return flags.isEnabled('SIMPLE_PROPERTIES_LIBRARY_COLOR') ? true : !showDisclaimer(data, handler);
         },
         items: {
           autoColor: {
@@ -519,10 +519,41 @@ export default function propertyDefinition(env) {
             },
             globalChange() {},
           },
+          baseColors: {
+            type: 'items',
+            items: {
+              useBaseColor: {
+                ref: 'color.point.useBaseColors',
+                show(data, handler) {
+                  const mode = getValue(data, 'color.point.mode', 'primary');
+                  return (
+                    flags.isEnabled('SIMPLE_PROPERTIES_LIBRARY_COLOR') &&
+                    !propsLogic.isColorAuto(data) &&
+                    mode === 'primary' &&
+                    (propsLogic.measuresHasBaseColors(handler) || propsLogic.dimensionsHasBaseColors(handler))
+                  );
+                },
+              },
+            },
+          },
           paletteColor: {
             ref: 'color.point.paletteColor',
             translation: 'properties.distributionPlot.pointColor',
             show: showPointPaletteColor,
+          },
+          // Switch for showing/hiding custom color schemes
+          useDimColVal: {
+            ref: 'color.point.useDimColVal',
+            show(data, handler, args) {
+              const libraryId = data.color.point?.byDimDef?.key ?? null;
+              const hasValueColors = propsLogic.hasDimValueColors(args.handler, libraryId);
+              return (
+                flags.isEnabled('SIMPLE_PROPERTIES_LIBRARY_COLOR') &&
+                hasValueColors &&
+                propsLogic.isColorByDimension(data) &&
+                propsLogic.isDimensionLibraryItem(data)
+              );
+            },
           },
           boxColor: {
             ref: 'color.box.paletteColor',


### PR DESCRIPTION
PS https://jira.qlikdev.com/browse/IM-1383

When enabled library color in simple mode under flag SIMPLE_PROPERTIES_LIBRARY_COLOR, dis plot chart should show library color dropdown/ library color switch.