### PR TITLE
Origin/viz 1628 styling panel histogram

### DIFF
--- a/charts/histogram/src/histogram-properties.js
+++ b/charts/histogram/src/histogram-properties.js
@@ -2,6 +2,7 @@ import { getValue } from 'qlik-chart-modules';
 import isInteger from '@qlik/common/extra/is-integer';
 import histogramUtils from './histogram-utils';
 import propsLogic from './histogram-properties-logic';
+import stylingPanelDefinition from './styling-panel-property-definition';
 
 const maxCountMode = 'maxCount';
 const sizeMode = 'size';
@@ -81,6 +82,8 @@ export default function propertyDefinition(env) {
     type: 'items',
     translation: 'properties.presentation',
     items: {
+      sliceStyling: stylingPanelDefinition,
+      sliceStyling: flags?.isEnabled('SENSECLIENT_IM_2021_STYLINGPANEL_HISTOGRAM') ? stylingPanelDefinition : {},
       gridLines: {
         type: 'items',
         snapshot: {

--- a/charts/histogram/src/histogram-properties.js
+++ b/charts/histogram/src/histogram-properties.js
@@ -16,7 +16,7 @@ function showBinCount(data) {
 }
 
 export default function propertyDefinition(env) {
-  const { translator } = env;
+  const { flags, translator } = env;
 
   const measureAxis = {
     uses: 'axis.picasso.measureAxis',
@@ -82,8 +82,7 @@ export default function propertyDefinition(env) {
     type: 'items',
     translation: 'properties.presentation',
     items: {
-      sliceStyling: stylingPanelDefinition,
-      sliceStyling: flags?.isEnabled('SENSECLIENT_IM_2021_STYLINGPANEL_HISTOGRAM') ? stylingPanelDefinition : {},
+      sliceStyling: flags?.isEnabled('SENSECLIENT_IM_2021_STYLINGPANEL_HISTOGRAM') ? stylingPanelDefinition : undefined,
       gridLines: {
         type: 'items',
         snapshot: {

--- a/charts/histogram/src/histogram-properties.js
+++ b/charts/histogram/src/histogram-properties.js
@@ -2,7 +2,7 @@ import { getValue } from 'qlik-chart-modules';
 import isInteger from '@qlik/common/extra/is-integer';
 import histogramUtils from './histogram-utils';
 import propsLogic from './histogram-properties-logic';
-import stylingPanelDefinition from './styling-panel-property-definition';
+import { stylingPanelDefinition } from './styling-panel-property-definition';
 
 const maxCountMode = 'maxCount';
 const sizeMode = 'size';
@@ -17,6 +17,9 @@ function showBinCount(data) {
 
 export default function propertyDefinition(env) {
   const { flags, translator } = env;
+
+  const stylingPanelEnabled = env.flags.isEnabled('SENSECLIENT_IM_2021_STYLINGPANEL_HISTOGRAM');
+  const bkgOptionsEnabled = env.flags.isEnabled('HISTOGRAM_BKG_OPTIONS');
 
   const measureAxis = {
     uses: 'axis.picasso.measureAxis',
@@ -82,7 +85,7 @@ export default function propertyDefinition(env) {
     type: 'items',
     translation: 'properties.presentation',
     items: {
-      sliceStyling: flags?.isEnabled('SENSECLIENT_IM_2021_STYLINGPANEL_HISTOGRAM') ? stylingPanelDefinition : undefined,
+      styleEditor: stylingPanelEnabled ? stylingPanelDefinition(bkgOptionsEnabled) : undefined,
       gridLines: {
         type: 'items',
         snapshot: {

--- a/charts/histogram/src/styling-panel-property-definition.js
+++ b/charts/histogram/src/styling-panel-property-definition.js
@@ -1,10 +1,11 @@
-const stylingPanelDefinition = {
+export const stylingPanelDefinition = (bkgOptionsEnabled) => {
+  return {
     component: 'styling-panel',
     chartTitle: 'Object.Histogram',
     translation: 'LayerStyleEditor.component.styling',
     subtitle: 'LayerStyleEditor.component.styling',
+    ref: 'components',
     useGeneral: true,
-    useBackground: true,
+    useBackground: bkgOptionsEnabled,
   };
-  
-  export default stylingPanelDefinition;
+};

--- a/charts/histogram/src/styling-panel-property-definition.js
+++ b/charts/histogram/src/styling-panel-property-definition.js
@@ -1,0 +1,7 @@
+export const stylingPanelDefinition = {
+  component: 'styling-panel',
+  chartTitle: 'Object.Histogram',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  useGeneral: true,
+};

--- a/charts/histogram/src/styling-panel-property-definition.js
+++ b/charts/histogram/src/styling-panel-property-definition.js
@@ -1,7 +1,9 @@
-export const stylingPanelDefinition = {
-  component: 'styling-panel',
-  chartTitle: 'Object.Histogram',
-  translation: 'LayerStyleEditor.component.styling',
-  subtitle: 'LayerStyleEditor.component.styling',
-  useGeneral: true,
-};
+const stylingPanelDefinition = {
+    component: 'styling-panel',
+    chartTitle: 'Object.Histogram',
+    translation: 'LayerStyleEditor.component.styling',
+    subtitle: 'LayerStyleEditor.component.styling',
+    useGeneral: true,
+  };
+  
+  export default stylingPanelDefinition;

--- a/charts/histogram/src/styling-panel-property-definition.js
+++ b/charts/histogram/src/styling-panel-property-definition.js
@@ -4,6 +4,7 @@ const stylingPanelDefinition = {
     translation: 'LayerStyleEditor.component.styling',
     subtitle: 'LayerStyleEditor.component.styling',
     useGeneral: true,
+    useBackground: true,
   };
   
   export default stylingPanelDefinition;


### PR DESCRIPTION
To enable the styling panel for the Histogram chart and to enable the background image and background color. 
<img width="254" alt="Screenshot 2022-11-18 at 6 44 42 PM 1" src="https://user-images.githubusercontent.com/104005788/202713657-59b15943-467b-4c5d-aa28-0cdef1ed345b.png">
