### PR TITLE
feat(dist-plot): enabled new styling panel

### DIFF
--- a/charts/distributionplot/src/distributionplot-properties.js
+++ b/charts/distributionplot/src/distributionplot-properties.js
@@ -8,6 +8,7 @@ import settingsRetriever from './sorting/distributionplot-sorting-settings-retri
 import elementsRetriever from './sorting/distributionplot-sorting-elements-retriever';
 import expressionSortOrderer from './sorting/distributionplot-expression-sort-orderer';
 import CONSTANTS from './distributionplot-constants';
+import getStylingPanelDefinition from './styling-panel-definition';
 
 function getNumMeasures(obj) {
   return getValue(obj, 'qHyperCubeDef.qMeasures.length', 0);
@@ -27,6 +28,10 @@ function persistentColorsShowFunc(data) {
 export default function propertyDefinition(env) {
   const { flags, translator } = env;
   const theme = env.anything.sense.theme;
+
+  // Feature Flags
+  const stylingPanelEnabled = env.flags.isEnabled('SENSECLIENT_IM_2018_STYLINGPANEL_DIST_PLOT');
+  const bkgOptionsEnabled = env.flags.isEnabled('DIST_BKG_OPTIONS');
 
   const lookupColorInPalette = (color) => {
     const palette = theme.getDataColorPickerPalettes()[0].colors;
@@ -172,6 +177,7 @@ export default function propertyDefinition(env) {
     type: 'items',
     translation: 'properties.presentation',
     items: {
+      styleEditor: stylingPanelEnabled && getStylingPanelDefinition(bkgOptionsEnabled),
       orientation: {
         ref: 'orientation',
         type: 'string',

--- a/charts/distributionplot/src/styling-panel-definition.js
+++ b/charts/distributionplot/src/styling-panel-definition.js
@@ -1,13 +1,11 @@
-const getStylingPanelDefinition = (bkgOptionsEnabled) => {
-  return {
-    component: 'styling-panel',
-    chartTitle: 'Object.DistributionPlot',
-    translation: 'LayerStyleEditor.component.styling',
-    subtitle: 'LayerStyleEditor.component.styling',
-    ref: 'components',
-    useGeneral: true,
-    useBackground: bkgOptionsEnabled,
-  };
-};
+const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
+  component: 'styling-panel',
+  chartTitle: 'Object.DistributionPlot',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  ref: 'components',
+  useGeneral: true,
+  useBackground: bkgOptionsEnabled,
+});
 
 export default getStylingPanelDefinition;

--- a/charts/distributionplot/src/styling-panel-definition.js
+++ b/charts/distributionplot/src/styling-panel-definition.js
@@ -1,0 +1,13 @@
+const getStylingPanelDefinition = (bkgOptionsEnabled) => {
+  return {
+    component: 'styling-panel',
+    chartTitle: 'Object.DistributionPlot',
+    translation: 'LayerStyleEditor.component.styling',
+    subtitle: 'LayerStyleEditor.component.styling',
+    ref: 'components',
+    useGeneral: true,
+    useBackground: bkgOptionsEnabled,
+  };
+};
+
+export default getStylingPanelDefinition;


### PR DESCRIPTION
This PR is to enable the new styling panel (`SENSECLIENT_IM_2018_STYLINGPANEL_DIST_PLOT`) with background options (`SENSECLIENT_IM_323_BACKGROUND_OPTIONS`) in the distribution plot