### PR TITLE
feat(waterfall-chart): enabled new styling panel

### DIFF
--- a/charts/waterfallchart/src/styling-panel-property-definiton.js
+++ b/charts/waterfallchart/src/styling-panel-property-definiton.js
@@ -1,0 +1,11 @@
+const getStylingPanelDefinition = (bkgOptionsEnabled) => ({
+  component: 'styling-panel',
+  chartTitle: 'Object.WaterfallChart',
+  translation: 'LayerStyleEditor.component.styling',
+  subtitle: 'LayerStyleEditor.component.styling',
+  ref: 'components',
+  useGeneral: true,
+  useBackground: bkgOptionsEnabled,
+});
+
+export default getStylingPanelDefinition;

--- a/charts/waterfallchart/src/waterfallchart-properties.js
+++ b/charts/waterfallchart/src/waterfallchart-properties.js
@@ -2,6 +2,7 @@ import extend from 'extend';
 import { getValue } from 'qlik-chart-modules';
 // import defaultProperties from '../../../assets/client/property-panel/default-properties';
 import waterfallUtils from './waterfallchart-utils';
+import getStylingPanelDefinition from './styling-panel-property-definiton';
 
 function colorIsNotAuto(data) {
   return !data.color.auto;
@@ -9,6 +10,9 @@ function colorIsNotAuto(data) {
 
 export default function propertyDefinition(env) {
   const { flags, translator } = env;
+  // feature flags
+  const stylingPanelEnabled = env.flags.isEnabled('SENSECLIENT_IM_2020_STYLINGPANEL_WATERFALLCHART');
+  const bkgOptionsEnabled = env.flags.isEnabled('WATERFALLCHART_BKG_OPTIONS');
   const data = {
     uses: 'data',
     addTranslation: 'Properties.AddData',
@@ -75,6 +79,7 @@ export default function propertyDefinition(env) {
     translation: 'properties.presentation',
     grouped: true,
     items: {
+      styleEditor: stylingPanelEnabled && getStylingPanelDefinition(bkgOptionsEnabled),
       gridLines: {
         type: 'items',
         snapshot: {


### PR DESCRIPTION
This PR is to enable the new styling panel (SENSECLIENT_IM_2020_STYLINGPANEL_WATERFALLCHART) with background options (WATERFALLCHART_BKG_OPTIONS) in the waterfall chart