### PR TITLE
fix: remove strokeWidth from brushed axis labels

### DIFF
--- a/chart-modules/common/picasso/chart-builder/components/axis.js
+++ b/chart-modules/common/picasso/chart-builder/components/axis.js
@@ -48,7 +48,11 @@ function axis(settings, options) {
       },
     },
   };
-  return extend(true, {}, defaultSettings, settings || {});
+  const axisSettings = extend(true, {}, defaultSettings, settings || {});
+  axisSettings.brush.consume.forEach((consume) => {
+    consume.style.active.strokeWidth = 0;
+  });
+  return axisSettings;
 }
 
 function xAxis(settings, options) {


### PR DESCRIPTION
picasso.js version 1.9.5 and later now apply strokeWidth to text this change should make the strokeWidth in the common bush style only apply to points and boxes.