### PR TITLE
fix: IM-4143-bring reference line in front of bars in distribution plot chart

### DIFF
--- a/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
+++ b/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
@@ -22,7 +22,9 @@ export default {
   refLines: {
     minimumLayoutMode: 'SPARK',
     prioOrder: 60,
-    displayOrder: -10,
+    layout: {
+      displayOrder: 10000,
+    },
   },
 
   // XMALL

--- a/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
+++ b/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
@@ -20,9 +20,9 @@ export default {
   },
 
   refLines: {
-    minimumLayoutMode: 'SPARK',
-    prioOrder: 60,
     layout: {
+      minimumLayoutMode: 'SPARK',
+      prioOrder: 60,
       displayOrder: 10000,
     },
   },

--- a/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
+++ b/chart-modules/common/picasso/chart-builder/presets/dimension-measure-chart/layout-settings.js
@@ -23,7 +23,7 @@ export default {
     layout: {
       minimumLayoutMode: 'SPARK',
       prioOrder: 60,
-      displayOrder: 10000,
+      displayOrder: 1110,
     },
   },
 


### PR DESCRIPTION
**The issue**: The Reference line on the distributionplot chart is always behind the “bars” of the chart. 

![Screenshot reference line](https://github.com/qlik-oss/dist-flow/assets/91126632/e4f43e3a-abc3-4400-8daa-ae6f65eb245d)

Fix: The reference line now should be in front of the bars.
 
![image](https://github.com/qlik-oss/dist-flow/assets/91126632/f3a363e8-d3d5-4a4d-be60-f73ef563e0cf)
