### PR TITLE
feat: add legend styling to dist and waterfall

### DIFF
--- a/chart-modules/common/extra/__tests__/chart-style-component.spec.js
+++ b/chart-modules/common/extra/__tests__/chart-style-component.spec.js
@@ -1,5 +1,12 @@
 import { fontResolver as createFontResolver } from 'qlik-chart-modules';
-import ChartStyleComponent, { getChartFontResolver } from '../chart-style-component';
+import ChartStyleComponent, {
+  getChartFontResolver,
+  getAxisLabelStyle,
+  getAxisTitleStyle,
+  getLegendLabelStyle,
+  getLegendTitleStyle,
+  getValueLabelStyle,
+} from '../chart-style-component';
 
 describe('ChartStyleComponent', () => {
   const ref = 'key.ref';
@@ -56,5 +63,85 @@ describe('ChartStyleComponent', () => {
       },
     };
     expect(JSON.stringify(chartStyleComponent.getOptions(key, ref))).toEqual(JSON.stringify(styleComponent));
+  });
+});
+
+describe('Styling options', () => {
+  let chartId;
+  let theme;
+  let layout;
+  let flags;
+
+  beforeEach(() => {
+    chartId = 'object';
+    flags = {
+      isEnabled: () => true,
+    };
+    layout = {};
+    theme = {
+      getStyle: jest.fn(),
+    };
+  });
+
+  it('should get corrext getAxisTitleStyle', () => {
+    const component = {
+      key: 'axis',
+      axis: { title: { fontFamily: 'aTitleFont, sans-serif', fontSize: '1000', fontColor: { color: 'red' } } },
+    };
+    layout.components = [component];
+    const style = getAxisTitleStyle(chartId, theme, layout, flags);
+    expect(style.text.fontFamily).toEqual('aTitleFont, sans-serif');
+    expect(style.text.fontSize).toEqual('1000');
+    expect(style.text.fill).toEqual('red');
+  });
+
+  it('should get corrext getAxisLabelStyle', () => {
+    const component = {
+      key: 'axis',
+      axis: {
+        label: { name: { fontFamily: 'aLabelFont, sans-serif', fontSize: '2000', fontColor: { color: 'green' } } },
+      },
+    };
+    layout.components = [component];
+    const style = getAxisLabelStyle(chartId, theme, layout, flags);
+    expect(style.labels.fontFamily).toEqual('aLabelFont, sans-serif');
+    expect(style.labels.fontSize).toEqual('2000');
+    expect(style.labels.fill).toEqual('green');
+  });
+
+  it('should get corrext getValueLabelStyle', () => {
+    const component = {
+      key: 'value',
+      label: { value: { fontFamily: 'vLabelFont, sans-serif', fontSize: '3000', fontColor: { color: 'blue' } } },
+    };
+    layout.components = [component];
+    const style = getValueLabelStyle(chartId, theme, layout, flags);
+    expect(style.fontFamily).toEqual('vLabelFont, sans-serif');
+    expect(style.fontSize).toEqual(3000);
+    expect(style.fill).toEqual('blue');
+  });
+
+  it('should get corrext getLegendTitleStyle', () => {
+    const component = {
+      key: 'legend',
+      legend: { title: { fontFamily: 'lTitleFont, sans-serif', fontSize: '4000', fontColor: { color: 'purple' } } },
+    };
+    layout.components = [component];
+    const style = getLegendTitleStyle(chartId, theme, layout, flags);
+    expect(style.fontFamily).toEqual('lTitleFont, sans-serif');
+    expect(style.fontSize).toEqual('4000');
+    expect(style.color).toEqual('purple');
+  });
+
+  it('should get corrext getLegendLabelStyle', () => {
+    const component = {
+      key: 'legend',
+      legend: { label: { fontFamily: 'lLabelFont, sans-serif', fontSize: '5000', fontColor: { color: 'yellow' } } },
+    };
+    layout.components = [component];
+    const style = getLegendLabelStyle(chartId, theme, layout, flags);
+    expect(style.fontFamily).toEqual('lLabelFont, sans-serif');
+    expect(style.fontSize).toEqual('5000');
+    expect(style.color).toEqual('yellow');
   });
 });

--- a/chart-modules/common/extra/chart-style-component.js
+++ b/chart-modules/common/extra/chart-style-component.js
@@ -64,7 +64,7 @@ export const getChartFontResolver = (theme, translator, chartId, createFontResol
     translator,
     config: {
       id: chartId,
-      paths: ['axis.title', 'axis.label.name', 'label.value'],
+      paths: ['axis.title', 'axis.label.name', 'label.value', 'legend.title', 'legend.label'],
     },
   });
 
@@ -101,6 +101,24 @@ export const getValueLabelStyle = (chartId, theme, layout, flags) => {
     fontFamily,
     fontSize,
     fill,
+  };
+};
+
+export const getLegendTitleStyle = (chartId, theme, layout, flags) => {
+  const legend = flags.isEnabled('CLIENT_IM_3051') ? overrides('legend', layout)?.legend : {};
+  return {
+    fontFamily: legend?.title?.fontFamily || theme.getStyle(chartId, 'legend.title', 'fontFamily'),
+    fontSize: legend?.title?.fontSize || theme.getStyle(chartId, 'legend.title', 'fontSize'),
+    color: legend?.title?.fontColor?.color || theme.getStyle(chartId, 'legend.title', 'color'),
+  };
+};
+
+export const getLegendLabelStyle = (chartId, theme, layout, flags) => {
+  const legend = flags.isEnabled('CLIENT_IM_3051') ? overrides('legend', layout)?.legend : {};
+  return {
+    fontFamily: legend?.label?.fontFamily || theme.getStyle(chartId, 'legend.label', 'fontFamily'),
+    fontSize: legend?.label?.fontSize || theme.getStyle(chartId, 'legend.label', 'fontSize'),
+    color: legend?.label?.fontColor?.color || theme.getStyle(chartId, 'legend.label', 'color'),
   };
 };
 

--- a/charts/distributionplot/src/distributionplot-view.js
+++ b/charts/distributionplot/src/distributionplot-view.js
@@ -11,8 +11,13 @@ import ScrollHandler from '@qlik/common/picasso/scroll/scroll-handler';
 import stringUtil from '@qlik/common/extra/string-util';
 import chartStyleUtils from '@qlik/common/extra/chart-style-utils';
 import hypercubeUtil from '@qlik/common/extra/hypercube-util';
+import {
+  getAxisLabelStyle,
+  getAxisTitleStyle,
+  getLegendLabelStyle,
+  getLegendTitleStyle,
+} from '@qlik/common/extra/chart-style-component';
 
-import { getAxisLabelStyle, getAxisTitleStyle } from '@qlik/common/extra/chart-style-component';
 import Jitter from './jitter';
 import columnOrderAdapter from './distributionplot-column-order-adapter';
 import CONSTANTS from './distributionplot-constants';
@@ -738,7 +743,12 @@ const DistributionPlot = ChartView.extend('DistributionPlot', {
         ? layout.legend.show !== false
         : !layout.color.point.auto && layout.color.point.mode === 'byDimension'; // For old apps without layout.legend
       if (showLegend) {
-        this.addLegend(chartBuilder, isRtl, legendSelectionSettings);
+        const styleOverrides = {
+          title: getLegendTitleStyle(CONSTANTS.CHART_ID, theme, layout, this.flags),
+          label: getLegendLabelStyle(CONSTANTS.CHART_ID, theme, layout, this.flags),
+        };
+
+        this.addLegend(chartBuilder, isRtl, legendSelectionSettings, styleOverrides);
       }
     }
 
@@ -758,13 +768,14 @@ const DistributionPlot = ChartView.extend('DistributionPlot', {
    * @param isRtl {Boolean}
    * @returns {void}
    */
-  addLegend(chartBuilder, isRtl, legendSelectionSettings) {
+  addLegend(chartBuilder, isRtl, legendSelectionSettings, styleOverrides) {
     const LEGEND_DISPLAY_OREDER = 200;
     const LEGEND_PRIO_ORDER = 50; // should be between axis (30) and refline (60) to be removed before axis but after refline
     const config = {
       eventName: 'legend-c',
       key: 'colorLegend',
       styleReference: 'object.comboChart',
+      styleOverrides,
       rtl: isRtl,
       settings: {
         item: {

--- a/charts/distributionplot/src/styling-panel-definition.js
+++ b/charts/distributionplot/src/styling-panel-definition.js
@@ -1,3 +1,41 @@
+/**
+ * Gets definition of items that should be in the styling panel for the chart.
+ * @param {*} flags
+ * @param {*} styleOptions
+ * @returns definition or undefined if nothing is toggled on by feature flags
+ */
+const getStylingItems = (flags, styleOptions) => {
+  const items = {};
+
+  if (flags?.isEnabled('CLIENT_IM_3364')) {
+    items.axisTitleSection = {
+      translation: 'properties.axis.title',
+      component: 'panel-section',
+      items: styleOptions.getOptions('axis', 'axis.title'),
+    };
+    items.axisLabelSection = {
+      translation: 'properties.axis.label',
+      component: 'panel-section',
+      items: styleOptions.getOptions('axis', 'axis.label.name'),
+    };
+  }
+
+  if (flags?.isEnabled('CLIENT_IM_3051')) {
+    items.legendTitleSection = {
+      translation: 'properties.legend.title',
+      component: 'panel-section',
+      items: styleOptions.getOptions('legend', 'legend.title'),
+    };
+    items.legendLabelSection = {
+      translation: 'properties.legend.label',
+      component: 'panel-section',
+      items: styleOptions.getOptions('legend', 'legend.label'),
+    };
+  }
+
+  return Object.keys(items).length > 0 ? items : undefined;
+};
+
 const getStylingPanelDefinition = (bkgOptionsEnabled, styleOptions, flags) => ({
   component: 'styling-panel',
   chartTitle: 'Object.DistributionPlot',
@@ -6,21 +44,7 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, styleOptions, flags) => ({
   ref: 'components',
   useGeneral: true,
   useBackground: bkgOptionsEnabled,
-  items:
-    flags && flags?.isEnabled('CLIENT_IM_3364')
-      ? {
-          axisTitleSection: {
-            translation: 'properties.axis.title',
-            component: 'panel-section',
-            items: styleOptions.getOptions('axis', 'axis.title'),
-          },
-          axisLabelSection: {
-            translation: 'properties.axis.label',
-            component: 'panel-section',
-            items: styleOptions.getOptions('axis', 'axis.label.name'),
-          },
-        }
-      : undefined,
+  items: getStylingItems(flags, styleOptions),
 });
 
 export default getStylingPanelDefinition;

--- a/charts/waterfallchart/src/__tests__/waterfallchart-view.spec.js
+++ b/charts/waterfallchart/src/__tests__/waterfallchart-view.spec.js
@@ -108,6 +108,7 @@ describe('Waterfallchart-view', () => {
   it('createChartSettings should create settings from layout', async () => {
     waterfallchart = new WaterfallChartView({ picasso, environment, $element });
     waterfallchart._tooltipHandler.setUp = sinon.mock().once().withArgs().returns({ trigger: {} });
+    waterfallchart.flags = { isEnabled: () => true };
     waterfallchart.getBarSettings = jest.fn();
     waterfallchart.createChartSettings(layout);
     expect(ChartStyleComponent.getAxisLabelStyle).have.been.calledOnce;

--- a/charts/waterfallchart/src/styling-panel-property-definiton.js
+++ b/charts/waterfallchart/src/styling-panel-property-definiton.js
@@ -1,3 +1,36 @@
+/**
+ * Gets definition of items that should be in the styling panel for the chart.
+ * @param {*} flags
+ * @param {*} styleOptions
+ * @returns definition or undefined if nothing is toggled on by feature flags
+ */
+const getStylingItems = (flags, styleOptions) => {
+  const items = {};
+
+  if (flags?.isEnabled('CLIENT_IM_3364')) {
+    items.axisLabelSection = {
+      translation: 'properties.axis.label',
+      component: 'panel-section',
+      items: styleOptions.getOptions('axis', 'axis.label.name'),
+    };
+    items.valueLabelSection = {
+      translation: 'properties.value.label',
+      component: 'panel-section',
+      items: styleOptions.getOptions('value', 'label.value'),
+    };
+  }
+
+  if (flags?.isEnabled('CLIENT_IM_3051')) {
+    items.legendLabelSection = {
+      translation: 'properties.legend.label',
+      component: 'panel-section',
+      items: styleOptions.getOptions('legend', 'legend.label'),
+    };
+  }
+
+  return Object.keys(items).length > 0 ? items : undefined;
+};
+
 const getStylingPanelDefinition = (bkgOptionsEnabled, styleOptions, flags) => ({
   component: 'styling-panel',
   chartTitle: 'Object.WaterfallChart',
@@ -6,21 +39,7 @@ const getStylingPanelDefinition = (bkgOptionsEnabled, styleOptions, flags) => ({
   ref: 'components',
   useGeneral: true,
   useBackground: bkgOptionsEnabled,
-  items:
-    flags && flags?.isEnabled('CLIENT_IM_3364')
-      ? {
-          axisLabelSection: {
-            translation: 'properties.axis.label',
-            component: 'panel-section',
-            items: styleOptions.getOptions('axis', 'axis.label.name'),
-          },
-          valueLabelSection: {
-            translation: 'properties.value.label',
-            component: 'panel-section',
-            items: styleOptions.getOptions('value', 'label.value'),
-          },
-        }
-      : undefined,
+  items: getStylingItems(flags, styleOptions),
 });
 
 export default getStylingPanelDefinition;

--- a/charts/waterfallchart/src/waterfallchart-view.js
+++ b/charts/waterfallchart/src/waterfallchart-view.js
@@ -6,7 +6,7 @@ import DependentInteractions from '@qlik/common/picasso/selections/dependent-int
 import TooltipHandler from '@qlik/common/picasso/tooltip/tooltips-handler';
 import formatting from '@qlik/common/picasso/formatting';
 import stringUtil from '@qlik/common/extra/string-util';
-import { getAxisLabelStyle, getValueLabelStyle } from '@qlik/common/extra/chart-style-component';
+import { getAxisLabelStyle, getValueLabelStyle, getLegendLabelStyle } from '@qlik/common/extra/chart-style-component';
 import CubeGenerator from './waterfallchart-cube-generator-by-measures';
 import waterfallUtils from './waterfallchart-utils';
 import tickGenerator from './waterfallchart-tick-generator';
@@ -249,7 +249,7 @@ function getBridgeSettings(isRtl, theme) {
   };
 }
 
-function getLegendSettings(environment, layout) {
+function getLegendSettings(environment, layout, flags) {
   const { theme, translator } = environment;
   const positveColor = waterfallUtils.getColorForPositiveValue(layout, theme);
   const negativeColor = waterfallUtils.getColorForNegativeValue(layout, theme);
@@ -257,6 +257,8 @@ function getLegendSettings(environment, layout) {
   const positiveText = translator.get('waterfall.legend.positiveValue.label');
   const negativeText = translator.get('waterfall.legend.negativeValue.label');
   const subtotalText = translator.get('waterfall.legend.subtotal.label');
+  const labelStyleSettings = getLegendLabelStyle(chartID, theme, layout, flags);
+
   return {
     displayOrder: 200,
     minimumLayoutMode: 'MEDIUM',
@@ -267,6 +269,13 @@ function getLegendSettings(environment, layout) {
       range: [positveColor, negativeColor, subtotalColor],
     },
     style: {
+      item: {
+        label: {
+          fontSize: labelStyleSettings.fontSize,
+          fontFamily: labelStyleSettings.fontFamily,
+          fill: labelStyleSettings.color,
+        },
+      },
       title: {
         show: false,
       },
@@ -376,7 +385,7 @@ function createChartSettings(layout) {
   chartBuilder.addComponent('point-marker', getBridgeSettings(isRtl, theme));
 
   if (!layout.legend || layout.legend.show) {
-    chartBuilder.addComponent('categorical-legend', getLegendSettings(this.environment, layout), {
+    chartBuilder.addComponent('categorical-legend', getLegendSettings(this.environment, layout, this.flags), {
       dock: layout.legend ? layout.legend.dock : 'auto',
       isRtl,
       chartWidth: width,


### PR DESCRIPTION
## Description

Adding the possibility to configure styling for the following properties for the dist and waterfall chart legends

- Legend title
- Legend labels

Flag is CLIENT_IM_3051

Properties added to the components array:
```
{
  "key": "legend",
  "legend": {
    "title": {
      "fontFamily": "Courier, monospace",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#ff5300" }
    },
    "label": {
      "fontFamily": "Didot, serif",
      "fontSize": "24px",
      "color": { "index": -1, "color": "#00ff0e" }
    }
  }
}
```
