### PR TITLE
add translation for overview in footer

### DIFF
--- a/chart-modules/common/locale/all.json
+++ b/chart-modules/common/locale/all.json
@@ -564,5 +564,11 @@
       "ja-JP": "99 番目の百分位数",
       "ru-RU": "99-й процентиль"
     }
+  },
+  "properties.compression.providingOverviewOf": {
+    "id": "properties.compression.providingOverviewOf",
+    "locale": {
+      "en-US": "Providing overview of {0} dimension values."
+    }
   }
 }


### PR DESCRIPTION
Overview footer is not getting localized when we render distribution chart in a new repo. (it works when we create chart in sheet view)

![Screen Shot 2023-10-19 at 10 03 50 AM](https://github.com/qlik-oss/dist-flow/assets/12648587/b8f84c44-3c62-45d9-93d2-150339ae6368)
