### PR TITLE
fix: showing limitation message when 3000 data points

### DIFF
--- a/charts/distributionplot/src/distributionplot-view.js
+++ b/charts/distributionplot/src/distributionplot-view.js
@@ -891,7 +891,7 @@ const DistributionPlot = ChartView.extend('DistributionPlot', {
     const showDisclaimer = this.flags.isEnabled('SHOW_DISCLAIMER') ? !(layout.showDisclaimer === false) : true;
     const limitedData =
       (!hypercubeUtil.hasSecondDimension(layout, DATA_PATH) && layout.qHyperCube.qSize.qcy > 10000) ||
-      (hypercubeUtil.hasSecondDimension(layout, DATA_PATH) && layout.qHyperCube.qSize.qcy > 3000);
+      (hypercubeUtil.hasSecondDimension(layout, DATA_PATH) && layout.qHyperCube.qSize.qcy >= CONSTANTS.MAX_STACKED_VALUES);
     const explicitLimitedData = showDisclaimer && limitedData;
     const scrollSettings = getPicassoScrollSettings(layout, this._scrollHandler.getScrollViewSizeInItem());
 

--- a/charts/distributionplot/src/distributionplot-view.js
+++ b/charts/distributionplot/src/distributionplot-view.js
@@ -891,7 +891,8 @@ const DistributionPlot = ChartView.extend('DistributionPlot', {
     const showDisclaimer = this.flags.isEnabled('SHOW_DISCLAIMER') ? !(layout.showDisclaimer === false) : true;
     const limitedData =
       (!hypercubeUtil.hasSecondDimension(layout, DATA_PATH) && layout.qHyperCube.qSize.qcy > 10000) ||
-      (hypercubeUtil.hasSecondDimension(layout, DATA_PATH) && layout.qHyperCube.qSize.qcy >= CONSTANTS.MAX_STACKED_VALUES);
+      (hypercubeUtil.hasSecondDimension(layout, DATA_PATH) &&
+        layout.qHyperCube.qSize.qcy >= CONSTANTS.MAX_STACKED_VALUES);
     const explicitLimitedData = showDisclaimer && limitedData;
     const scrollSettings = getPicassoScrollSettings(layout, this._scrollHandler.getScrollViewSizeInItem());
 


### PR DESCRIPTION
For some reason when it reaches the max it already loses data points. Not an expert here, but adding the message when that happens seems the correct way (will keep the same data shown for now at least)

Before:

![image](https://github.com/qlik-oss/dist-flow/assets/25658598/1a1ef54d-0282-4f8b-8d67-d8ced2c801ed)

After:

![image](https://github.com/qlik-oss/dist-flow/assets/25658598/54383f55-2bc6-4f9b-a189-c089e04cd718)
